### PR TITLE
Fix to support Expo 47

### DIFF
--- a/build/withWatermelon.d.ts
+++ b/build/withWatermelon.d.ts
@@ -1,2 +1,2 @@
-declare const _default: (config: any) => any;
+declare const _default: (config: any, options: any) => any;
 export default _default;


### PR DESCRIPTION
Fix for iOS build:

Applied fixes from coffeOwl shared here: https://github.com/expo/expo/issues/18784#issuecomment-1333726866

Fix for Android build:

Added the watermelon db package to the main activity init package list as it appears to be needed (i.e. auto-linking is not working for me). 

Also added an escape for the simulator architecture exclusion to the config option for the expo plugin.