### PR TITLE
Prebuild error fix for app name with spaces

### DIFF
--- a/build/withWatermelon.js
+++ b/build/withWatermelon.js
@@ -32,7 +32,7 @@ function setAppDelegate(config) {
     return (0, config_plugins_1.withDangerousMod)(config, [
         "ios",
         async (config) => {
-            const filePath = path_1.default.join(config.modRequest.platformProjectRoot, config.name.replace("-", ""), "AppDelegate.h");
+            const filePath = getPlatformProjectFilePath(config, 'AppDelegate.h');
             const contents = await fs.readFile(filePath, "utf-8");
             let updated = `#import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
@@ -51,7 +51,7 @@ function setWmelonBridgingHeader(config) {
     return (0, config_plugins_1.withDangerousMod)(config, [
         "ios",
         async (config) => {
-            const filePath = path_1.default.join(config.modRequest.projectRoot + "/ios", config.name.replace("-", ""), "wmelon.swift");
+            const filePath = getPlatformProjectFilePath(config, 'wmelon.swift');
             const contents = `
 //
 //  water.swift
@@ -118,11 +118,9 @@ function isWatermelonDBInstalled(projectRoot) {
     const resolved = resolve_from_1.default.silent(projectRoot, "@nozbe/watermelondb/package.json");
     return resolved ? path_1.default.dirname(resolved) : null;
 }
-function replace(contents, match, replace) {
-    // @ts-ignore
-    if (!(match.test ? RegExp(match).test(contents) : contents.includes(match)))
-        throw new Error("Invalid text replace in config");
-    return contents.replace(match, replace);
+function getPlatformProjectFilePath(config, fileName) {
+    const projectName = config.modRequest.projectName || config.name.replace(/[- ]/g, '');
+    return path_1.default.join(config.modRequest.platformProjectRoot, projectName, fileName);
 }
 // @ts-ignore
 exports.default = (config, options) => {

--- a/src/withWatermelon.ts
+++ b/src/withWatermelon.ts
@@ -45,11 +45,7 @@ function setAppDelegate(config: ExportedConfigWithProps) {
   return withDangerousMod(config, [
     "ios",
     async (config) => {
-      const filePath = path.join(
-        config.modRequest.platformProjectRoot,
-        config.name.replace("-", ""),
-        "AppDelegate.h"
-      );
+      const filePath = getPlatformProjectFilePath(config, 'AppDelegate.h')
       const contents = await fs.readFile(filePath, "utf-8");
 
       let updated =
@@ -73,12 +69,7 @@ function setWmelonBridgingHeader(config: ExportedConfigWithProps) {
   return withDangerousMod(config, [
     "ios",
     async (config) => {
-      const filePath = path.join(
-        config.modRequest.projectRoot + "/ios",
-        config.name.replace("-", ""),
-        "wmelon.swift"
-      );
-
+      const filePath = getPlatformProjectFilePath(config, 'wmelon.swift')
       const contents = `
 //
 //  water.swift
@@ -165,12 +156,13 @@ function isWatermelonDBInstalled(projectRoot: string) {
   return resolved ? path.dirname(resolved) : null;
 }
 
-function replace(contents: string, match: string, replace: string): string {
-  // @ts-ignore
-  if (!(match.test ? RegExp(match).test(contents) : contents.includes(match)))
-    throw new Error("Invalid text replace in config");
-
-  return contents.replace(match, replace);
+function getPlatformProjectFilePath(config: ExportedConfigWithProps, fileName: string) {
+  const projectName = config.modRequest.projectName || config.name.replace(/[- ]/g, '')
+  return path.join(
+    config.modRequest.platformProjectRoot,
+    projectName,
+    fileName
+  )
 }
 
 // @ts-ignore


### PR DESCRIPTION
Fix for this error I was getting during prebuild:

```
- Config syncing
✖ Config sync failed
[stderr] [12:32:43] [ios.dangerous]: withIosDangerousBaseMod: ENOENT: no such file or directory, open '/Users/expo/workingdir/build/ios/My App Name/wmelon.swift'
[stderr] [12:32:43] Error: [ios.dangerous]: withIosDangerousBaseMod: ENOENT: no such file or directory, open '/Users/expo/workingdir/build/ios/My App Name/wmelon.swift'
[stderr] error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
yarn exited with non-zero code: 1
```

Think it was associated to my app name having spaces and this code:

`config.modRequest.projectRoot + "/ios", config.name.replace("-", "")`

Was returning an incorrect projectName

Kinda new to RN and am happy to make edits to this if anyone has more context