### PR TITLE
Configuring databases for Flipper on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ In your app.json `plugins` array:
 
 ```json
 {
-  "plugins": ["@morrowdigital/watermelondb-expo-plugin",
+  "plugins": [
+      [
+        "@morrowdigital/watermelondb-expo-plugin",
+        {
+          "databases": ["morrow.db"]
+        }
+      ],
       [
         "expo-build-properties",
         {

--- a/build/withWatermelon.js
+++ b/build/withWatermelon.js
@@ -26,6 +26,46 @@ function setAndroidMainApplication(config) {
     ]);
 }
 /**
+ * Platform: Android
+ *  */
+function addFlipperDb(config, databases) {
+    return (0, config_plugins_1.withDangerousMod)(config, [
+        "android",
+        async (config) => {
+            // short circuit if no databases specified
+            if (!databases?.length)
+                return config;
+            const root = config.modRequest.platformProjectRoot;
+            const filePath = `${root}/app/src/debug/java/${config?.android?.package?.replace(/\./g, "/")}/ReactNativeFlipper.java`;
+            const contents = await fs.readFile(filePath, "utf-8");
+            // Add imports
+            let updated = (0, insertLinesHelper_1.insertLinesHelper)(`import com.facebook.flipper.plugins.databases.impl.SqliteDatabaseDriver;
+import com.facebook.flipper.plugins.databases.impl.SqliteDatabaseProvider;
+import java.io.File;
+import java.util.List;
+import java.util.ArrayList;`, "import okhttp3.OkHttpClient;", contents);
+            // Replace DatabasesFlipperPlugin with custom driver
+            const addDatabases = databases
+                .map((d) => `databaseFiles.add(new File(context.getDatabasePath("${d}").getPath().replace("/databases", "")));`)
+                .join("\n          ");
+            updated = (0, insertLinesHelper_1.insertLinesHelper)(`      client.addPlugin(new DatabasesFlipperPlugin(new SqliteDatabaseDriver(context, new SqliteDatabaseProvider() {
+        @Override
+        public List<File> getDatabaseFiles() {
+          List<File> databaseFiles = new ArrayList<>();
+          for (String databaseName : context.databaseList()) {
+            databaseFiles.add(context.getDatabasePath(databaseName));
+          }
+          ${addDatabases}
+          return databaseFiles;
+        }
+      })));`, "client.addPlugin(new DatabasesFlipperPlugin(context));", updated, 0, // replace original plugin
+            1);
+            await fs.writeFile(filePath, updated);
+            return config;
+        },
+    ]);
+}
+/**
  * Platform: iOS
  *  */
 function setAppDelegate(config) {
@@ -127,6 +167,7 @@ exports.default = (config, options) => {
     // config = setAppSettingBuildGradle(config);
     // config = setAppBuildGradle(config);
     config = setAndroidMainApplication(config);
+    config = addFlipperDb(config, options?.databases ?? []);
     config = setAppDelegate(config);
     config = setWmelonBridgingHeader(config);
     config = withCocoaPods(config);

--- a/example/app.json
+++ b/example/app.json
@@ -32,7 +32,12 @@
       "favicon": "./assets/favicon.png"
     },
     "plugins": [
-      "@morrowdigital/watermelondb-expo-plugin",
+      [
+        "@morrowdigital/watermelondb-expo-plugin",
+        {
+          "databases": ["morrow.db"]
+        }
+      ],
       [
         "expo-build-properties",
         {

--- a/src/withWatermelon.ts
+++ b/src/withWatermelon.ts
@@ -39,6 +39,70 @@ function setAndroidMainApplication(config: ExportedConfigWithProps) {
 }
 
 /**
+ * Platform: Android
+ *  */
+function addFlipperDb(config: ExportedConfigWithProps, databases: string[]) {
+  return withDangerousMod(config, [
+    "android",
+    async (config) => {
+      // short circuit if no databases specified
+      if (!databases?.length) return config;
+
+      const root = config.modRequest.platformProjectRoot;
+      const filePath = `${root}/app/src/debug/java/${config?.android?.package?.replace(
+        /\./g,
+        "/"
+      )}/ReactNativeFlipper.java`;
+
+      const contents = await fs.readFile(filePath, "utf-8");
+
+      // Add imports
+
+      let updated = insertLinesHelper(
+        `import com.facebook.flipper.plugins.databases.impl.SqliteDatabaseDriver;
+import com.facebook.flipper.plugins.databases.impl.SqliteDatabaseProvider;
+import java.io.File;
+import java.util.List;
+import java.util.ArrayList;`,
+        "import okhttp3.OkHttpClient;",
+        contents
+      );
+
+      // Replace DatabasesFlipperPlugin with custom driver
+
+      const addDatabases = databases
+        .map(
+          (d) =>
+            `databaseFiles.add(new File(context.getDatabasePath("${d}").getPath().replace("/databases", "")));`
+        )
+        .join("\n          ");
+
+      updated = insertLinesHelper(
+        `      client.addPlugin(new DatabasesFlipperPlugin(new SqliteDatabaseDriver(context, new SqliteDatabaseProvider() {
+        @Override
+        public List<File> getDatabaseFiles() {
+          List<File> databaseFiles = new ArrayList<>();
+          for (String databaseName : context.databaseList()) {
+            databaseFiles.add(context.getDatabasePath(databaseName));
+          }
+          ${addDatabases}
+          return databaseFiles;
+        }
+      })));`,
+        "client.addPlugin(new DatabasesFlipperPlugin(context));",
+        updated,
+        0, // replace original plugin
+        1
+      );
+
+      await fs.writeFile(filePath, updated);
+
+      return config;
+    },
+  ]);
+}
+
+/**
  * Platform: iOS
  *  */
 function setAppDelegate(config: ExportedConfigWithProps) {
@@ -170,6 +234,7 @@ export default (config, options) => {
   // config = setAppSettingBuildGradle(config);
   // config = setAppBuildGradle(config);
   config = setAndroidMainApplication(config);
+  config = addFlipperDb(config, options?.databases ?? []);
   config = setAppDelegate(config);
   config = setWmelonBridgingHeader(config);
   config = withCocoaPods(config);


### PR DESCRIPTION
React Native sets up [Flipper](https://fbflipper.com/) support automatically, but it [doesn't detect Watermelon SQLite databases by default](https://github.com/Nozbe/WatermelonDB/issues/653)

This proposed change updates the auto-generated ReactNativeFlipper.java so that Watermelon databases can be configured in your expo `app.json` and will be made visible for debugging in Flipper.