### PR TITLE
fix prebuild duplicating strings

### DIFF
--- a/build/withWatermelon.js
+++ b/build/withWatermelon.js
@@ -42,10 +42,12 @@ function settingGradle(gradleConfig) {
 }
 function buildGradle(config) {
     return (0, config_plugins_1.withAppBuildGradle)(config, (mod) => {
-        const newContents = mod.modResults.contents.replace('dependencies {', `dependencies {
-        implementation project(':watermelondb-jsi')
-        `);
-        mod.modResults.contents = newContents;
+        if (!mod.modResults.contents.includes("implementation project(':watermelondb-jsi')")) {
+            const newContents = mod.modResults.contents.replace('dependencies {', `dependencies {
+            implementation project(':watermelondb-jsi')
+            `);
+            mod.modResults.contents = newContents;
+        }
         return mod;
     });
 }
@@ -68,28 +70,34 @@ const cocoaPods = (config) => {
 };
 function mainApplication(config) {
     return (0, config_plugins_1.withMainApplication)(config, (mod) => {
-        mod.modResults['contents'] = mod.modResults.contents.replace('import android.app.Application', `
+        if (!mod.modResults.contents.includes("import com.nozbe.watermelondb.jsi.WatermelonDBJSIPackage")) {
+            mod.modResults['contents'] = mod.modResults.contents.replace('import android.app.Application', `
 import android.app.Application
 import com.nozbe.watermelondb.jsi.WatermelonDBJSIPackage;
 import com.facebook.react.bridge.JSIModulePackage;        
 `);
-        const newContents2 = mod.modResults.contents.replace('override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED', `
+        }
+        if (!mod.modResults.contents.includes("override fun getJSIModulePackage(): JSIModulePackage")) {
+            const newContents2 = mod.modResults.contents.replace('override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED', `
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
         override fun getJSIModulePackage(): JSIModulePackage {
         return WatermelonDBJSIPackage()
         }`);
-        mod.modResults.contents = newContents2;
+            mod.modResults.contents = newContents2;
+        }
         return mod;
     });
 }
 function proGuardRules(config) {
     return (0, config_plugins_1.withDangerousMod)(config, ['android', async (config) => {
             const contents = await fs.readFile(`${config.modRequest.platformProjectRoot}/app/proguard-rules.pro`, 'utf-8');
-            const newContents = `
+            if (!contents.includes("-keep class com.nozbe.watermelondb.** { *; }")) {
+                const newContents = `
     ${contents}
     -keep class com.nozbe.watermelondb.** { *; }
     `;
-            await fs.writeFile(`${config.modRequest.platformProjectRoot}/app/proguard-rules.pro`, newContents);
+                await fs.writeFile(`${config.modRequest.platformProjectRoot}/app/proguard-rules.pro`, newContents);
+            }
             return config;
         }]);
 }
@@ -163,13 +171,15 @@ const withCocoaPods = (config) => {
             const contents = await fs.readFile(filePath, "utf-8");
             const watermelonPath = isWatermelonDBInstalled(config.modRequest.projectRoot);
             if (watermelonPath) {
-                const patchKey = "post_install";
-                const slicedContent = contents.split(patchKey);
-                slicedContent[0] += `\n
+                if (!contents.includes("pod 'WatermelonDB', :path => '../node_modules/@nozbe/watermelondb'")) {
+                    const patchKey = "post_install";
+                    const slicedContent = contents.split(patchKey);
+                    slicedContent[0] += `\n
   pod 'WatermelonDB', :path => '../node_modules/@nozbe/watermelondb'
   pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi', :modular_headers => true
   pod 'simdjson', path: '../node_modules/@nozbe/simdjson', :modular_headers => true\n\n  `;
-                await fs.writeFile(filePath, slicedContent.join(patchKey));
+                    await fs.writeFile(filePath, slicedContent.join(patchKey));
+                }
             }
             else {
                 throw new Error("Please make sure you have watermelondb installed");


### PR DESCRIPTION
If I run `expo prebuild` more than once, the injected config strings are executed multiple times, resulting into buggy files

This PR add conditionals to avoid creating duplicated config strings

Please, note that I didn't compiled the plugin then the code style format could be different if you run locally. Feel free to update the PR to match the correct code style guide

![Screenshot 2024-04-12 at 02 14 55](https://github.com/morrowdigital/watermelondb-expo-plugin/assets/557598/ac897d28-d1a8-4188-a006-15eb5bcb87fc)

![Screenshot 2024-04-12 at 02 15 03](https://github.com/morrowdigital/watermelondb-expo-plugin/assets/557598/b6acba85-4cb2-4683-9370-3a19989c08d8)

![Screenshot 2024-04-12 at 02 15 21](https://github.com/morrowdigital/watermelondb-expo-plugin/assets/557598/71b664b7-dcc5-4411-b124-2ff216434696)

![Screenshot 2024-04-12 at 02 15 27](https://github.com/morrowdigital/watermelondb-expo-plugin/assets/557598/87439ce4-7821-452e-a75b-0f8e094df9f7)

