### PR TITLE
fix: fix issue with sdk 52 and watermelonDB 0.28.0-1

### DIFF
--- a/build/withWatermelon.js
+++ b/build/withWatermelon.js
@@ -100,7 +100,7 @@ import com.nozbe.watermelondb.jsi.WatermelonDBJSIPackage;
         }
         if (!mod.modResults.contents.includes("packages.add(WatermelonDBJSIPackage())")) {
             const newContents2 = mod.modResults.contents.replace('return packages', `
-        packages.add(WatermelonDBJSIPackage())
+            packages.add(WatermelonDBJSIPackage())
         return packages`);
             mod.modResults.contents = newContents2;
         }

--- a/build/withWatermelon.js
+++ b/build/withWatermelon.js
@@ -90,6 +90,23 @@ import com.facebook.react.bridge.JSIModulePackage;
         return mod;
     });
 }
+function mainApplicationSDK52(config) {
+    return (0, config_plugins_1.withMainApplication)(config, (mod) => {
+        if (!mod.modResults.contents.includes("import com.nozbe.watermelondb.jsi.WatermelonDBJSIPackage")) {
+            mod.modResults['contents'] = mod.modResults.contents.replace('import android.app.Application', `
+import android.app.Application
+import com.nozbe.watermelondb.jsi.WatermelonDBJSIPackage;        
+`);
+        }
+        if (!mod.modResults.contents.includes("packages.add(WatermelonDBJSIPackage())")) {
+            const newContents2 = mod.modResults.contents.replace('return packages', `
+        packages.add(WatermelonDBJSIPackage())
+        return packages`);
+            mod.modResults.contents = newContents2;
+        }
+        return mod;
+    });
+}
 function proGuardRules(config) {
     return (0, config_plugins_1.withDangerousMod)(config, ['android', async (config) => {
             const contents = await fs.readFile(`${config.modRequest.platformProjectRoot}/app/proguard-rules.pro`, 'utf-8');
@@ -277,7 +294,10 @@ function withSDK50(options) {
             currentConfig = settingGradle(config);
             currentConfig = buildGradle(currentConfig);
             currentConfig = proGuardRules(currentConfig);
-            currentConfig = mainApplication(currentConfig);
+            // Only manual link package on sdk 52+ as descripted here:
+            // https://github.com/Nozbe/WatermelonDB/issues/1769#issuecomment-2600274652
+            currentConfig = config.sdkVersion && config.sdkVersion >= '52.0.0' ?
+                mainApplicationSDK52(currentConfig) : mainApplication(currentConfig);
         }
         // iOS
         currentConfig = withCocoaPods(currentConfig);

--- a/src/withWatermelon.ts
+++ b/src/withWatermelon.ts
@@ -132,6 +132,29 @@ import com.facebook.react.bridge.JSIModulePackage;
   }) as ExpoConfig;
 }
 
+function mainApplicationSDK52(config: ExpoConfig): ExpoConfig {
+  return withMainApplication(config, (mod) => {
+    if (!mod.modResults.contents.includes("import com.nozbe.watermelondb.jsi.WatermelonDBJSIPackage")) {
+      mod.modResults['contents'] = mod.modResults.contents.replace('import android.app.Application', `
+import android.app.Application
+import com.nozbe.watermelondb.jsi.WatermelonDBJSIPackage;        
+`);
+    }
+
+    if (!mod.modResults.contents.includes("packages.add(WatermelonDBJSIPackage())")) {
+      const newContents2 = mod.modResults.contents.replace(
+          'return packages',
+          `
+        packages.add(WatermelonDBJSIPackage())
+        return packages`
+      )
+      mod.modResults.contents = newContents2;
+    }
+
+    return mod;
+  }) as ExpoConfig;
+}
+
 function proGuardRules(config: ExpoConfig): ExpoConfig {
   return withDangerousMod(config, ['android', async (config) => {
     const contents = await fs.readFile(`${config.modRequest.platformProjectRoot}/app/proguard-rules.pro`, 'utf-8');
@@ -405,7 +428,10 @@ export function withSDK50(options: Options) {
       currentConfig = settingGradle(config);
       currentConfig = buildGradle(currentConfig);
       currentConfig = proGuardRules(currentConfig);
-      currentConfig = mainApplication(currentConfig);
+      // Only manual link package on sdk 52+ as descripted here:
+      // https://github.com/Nozbe/WatermelonDB/issues/1769#issuecomment-2600274652
+      currentConfig = config.sdkVersion && config.sdkVersion >= '52.0.0' ?
+          mainApplicationSDK52(currentConfig) : mainApplication(currentConfig);
     }
 
     // iOS

--- a/src/withWatermelon.ts
+++ b/src/withWatermelon.ts
@@ -145,7 +145,7 @@ import com.nozbe.watermelondb.jsi.WatermelonDBJSIPackage;
       const newContents2 = mod.modResults.contents.replace(
           'return packages',
           `
-        packages.add(WatermelonDBJSIPackage())
+            packages.add(WatermelonDBJSIPackage())
         return packages`
       )
       mod.modResults.contents = newContents2;


### PR DESCRIPTION
When using expo sdk 52 and watermelonDB 0.28.0-1, the expo autolinking does not work and therefore we must manually link it to enable jsi.

As the plugin is currently still trying to add JSI package function this was removed for expo sdk 52+. :)